### PR TITLE
Ability to drain a pool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ specifies the caller's relative position in the queue.
 
      // etc..
 
+## Draining
+
+If you know would like to terminate all the resources in your queue before
+their timeouts have been reached, you can use `shutdownNow()` in conjunction
+with `drain()`:
+
+    pool.drain(function() {
+	    pool.destroyAllNow();
+    });
+
+One side-effect of calling `drain()` is that subsequent calls to `acquire()`
+will throw an Error.
+
 ## Run Tests
 
     $ npm install expresso

--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -96,6 +96,7 @@ exports.Pool = function (factory) {
       waitingClients = new PriorityQueue(factory.priorityRange || 1),
       count = 0,
       removeIdleScheduled = false,
+      draining = false,
 
       // Prepare a logger function.
       log = factory.log ?
@@ -221,6 +222,9 @@ exports.Pool = function (factory) {
    *   priority.
    */
   me.acquire = function (callback, priority) {
+    if (draining) {
+      throw new Error("pool is draining and cannot accept work");
+    }
     waitingClients.enqueue(callback, priority);
     dispense();
   };
@@ -249,6 +253,57 @@ exports.Pool = function (factory) {
     log("returnToPool() is deprecated. use release() instead");
     me.release(obj);
   };
+
+  /**
+   * Disallow any new requests and let the request backlog dissapate.
+   * 
+   * @param {Function} callback
+   *   Optional. Callback invoked when all work is done and all clients have been
+   *   released.
+   */
+  me.drain = function(callback) {
+    log("draining");
+    
+    // disable the ability to put more work on the queue.
+    draining = true;
+     
+    var check = function() {
+      if (waitingClients.size() > 0) {
+        // wait until all client requests have been satisfied.
+        setTimeout(check, 100);
+      } else if (availableObjects.length != count) {
+        // wait until all objects have been released.
+        setTimeout(check, 100);
+      } else {
+        if (callback) {
+          callback();
+        }
+      }
+    };
+    check();
+  };
+
+  /**
+   * Forcibly destroys all clients regardless of timeout.  Intended to be
+   * invoked as part of a drain.  Does not prevent the creation of new
+   * clients as a result of subsequent calls to acquire.
+   * 
+   * @param {Function} callback
+   *   Optional. Callback invoked after all existing clients are destroyed.
+   */
+  me.destroyAllNow = function(callback) {
+    log("force destroying all objects");
+    var willDie = availableObjects;
+    availableObjects = [];
+    var obj = willDie.shift();
+    while (obj != null) {
+      destroy(obj.obj);
+      obj = willDie.shift();
+    }
+    if (callback) {
+      callback();
+    }
+  }
 
   return me;
 };


### PR DESCRIPTION
We are looking at using generic-pool in a cassandra client to manage connection pooling.  We found it useful to be able to 'shutdown' a pool (make it so that it no longer accepts work, and provide notification when all work is done).
