### PR TITLE
Allow errors in callback to acquire, make tests stricter

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -174,6 +174,20 @@ exports.Pool = function (factory) {
   }
 
   /**
+   * Handle callbacks with either the [obj] or [err, obj] arguments in an
+   * adaptive manner. Uses the `cb.length` property to determine the number
+   * of arguments expected by `cb`.
+   */
+  function adjustCallback(cb, err, obj) {
+    if (!cb) return;
+    if (cb.length <= 1) {
+      cb(obj);
+    } else {
+      cb(err, obj);
+    }
+  };
+
+  /**
    * Try to get a new client to work, and clean up pool unused (idle) items.
    *
    *  - If there are available clients waiting shift the first one out (LIFO),
@@ -185,23 +199,36 @@ exports.Pool = function (factory) {
    */
   function dispense() {
     var obj = null,
+        err = null,
         waitingCount = waitingClients.size();
     log("dispense() clients=" + waitingCount + " available=" + availableObjects.length);
     if (waitingCount > 0) {
       if (availableObjects.length > 0) {
         log("dispense() - reusing obj");
         objWithTimeout = availableObjects.shift();
-        waitingClients.dequeue()(null, objWithTimeout.obj);
+        adjustCallback(waitingClients.dequeue(), err, objWithTimeout.obj);
       }
       else if (count < factory.max) {
         count += 1;
         log("dispense() - creating obj - count=" + count);
-        factory.create(function (err, obj) {
+        factory.create(function () {
           var cb = waitingClients.dequeue();
-          if (cb) {
-            cb(err, obj);
+          if (arguments.length > 1) {
+            err = arguments[0];
+            obj = arguments[1];
           } else {
-            me.release(obj);
+            err = (arguments[0] instanceof Error) ? arguments[0] : null;
+            obj = (arguments[0] instanceof Error) ? null : arguments[0];
+          }
+          if (err) {
+            count -= 1;
+            adjustCallback(cb, err, obj);
+          } else {
+            if (cb) {
+              adjustCallback(cb, err, obj);
+            } else {
+              me.release(obj);
+            }
           }
         });
       }


### PR DESCRIPTION
This commit definitely breaks the API in order to allow two things: the acquire function now calls a callback with `(err, result)` instead of just `(result)`, which didn't allow for many error cases. And, in order to do cleanup from this kind of situation, `destroy(callback)` is now on `me.` so that users can call it to destroy objects that can't be repaired on their side.
