### PR TITLE
Prevent intermittent, hidden consequences when release is called twice on the same resource

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -269,6 +269,11 @@ exports.Pool = function (factory) {
    *   The acquired object to be put back to the pool.
    */
   me.release = function (obj) {
+	// check to see if this object has already been release (i.e., is back in the pool of availableObjects)
+    if (availableObjects.some(function(objWithTimeout) { return (objWithTimeout.obj === obj); })) {
+      log("release called twice for the same resource: " + (new Error().stack));
+      return;
+    }
     //log("return to pool");
     var objWithTimeout = { obj: obj, timeout: (new Date().getTime() + idleTimeoutMillis) };
     availableObjects.push(objWithTimeout);


### PR DESCRIPTION
Without this fix, if release is called twice on a resource, it will end up allowing two clients to acquire the resource simultaneously.  We spent an entire day trying to figure out why redis was intermittently failing to invoke a callback, until we discovered the multiple releases at 2am...  Let's prevent others from suffering the same fate.  

BTW, it's rather easy to accidentally release twice:

E.g., 

pool.acquire(function(err, resource) {
   resource.use(function(err, data) {
     if (err) { 
         cb(err);
         pool.release(resource);
     } else {
         if (data) {
             cb(null, data);
         }
     }
     pool.release(resource);
   }
}
