### PR TITLE
API should give feedback on pool committment level

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -248,6 +248,8 @@ exports.Pool = function (factory) {
    *   Optional.  Integer between 0 and (priorityRange - 1).  Specifies the priority
    *   of the caller if there are no available resources.  Lower numbers mean higher
    *   priority.
+   *
+   * @returns {Object} `true` if the pool is fully utilized, `false` otherwise.
    */
   me.acquire = function (callback, priority) {
     if (draining) {
@@ -255,6 +257,7 @@ exports.Pool = function (factory) {
     }
     waitingClients.enqueue(callback, priority);
     dispense();
+    return (count < factory.max);
   };
   
   me.borrow = function (callback, priority) {

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -19,7 +19,7 @@ module.exports = {
         });
     
         for (var i = 0; i < 10; i++) {
-            pool.acquire(function(err, obj) {
+            var full = !pool.acquire(function(err, obj) {
                 return function(err, obj) {
                     assert.equal(typeof obj.count, 'number');
                     setTimeout(function() {
@@ -28,6 +28,7 @@ module.exports = {
                     }, 100);
                 };
             }());
+            assert.ok((i < 1) ^ full);
         }
     
         beforeExit(function() {


### PR DESCRIPTION
I wrote [this answer](http://stackoverflow.com/questions/6623683/node-js-process-out-of-memory-in-http-request-loop/7468792#7468792) on SO after someone recommended node-pool. However, node-pool does not the solve the problem because it queues excess requests without informing the caller about the status of the pool.

I will update the answer on Stack Overflow if this change is accepted.
