### PR TITLE
Adding getter methods to see pool size, etc.

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -342,7 +342,7 @@ exports.Pool = function (factory) {
     }
   };
 
-  me.getCount = function() {
+  me.getPoolSize = function() {
     return count;
   };
 


### PR DESCRIPTION
This fork adds a few functions to give us visibility to the pool size and related info.

  me.getPoolSize = function() {
    return count;
  };

  me.availableObjectsCount = function() {
    return availableObjects.length;
  };

  me.waitingClientsCount = function() {
    return waitingClients.size();
  };
