### PR TITLE
Remove client from availbleObjects on destroy(client)

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -136,7 +136,7 @@ exports.Pool = function (factory) {
         al,
         timeout;
 
-    removeIdleScheduled = false;
+    unscheduleRemoveIdle();
 
     // Go through the available (idle) items,
     // check if they have timed out
@@ -172,8 +172,19 @@ exports.Pool = function (factory) {
    */
   function scheduleRemoveIdle() {
     if (!removeIdleScheduled) {
-      removeIdleScheduled = true;
-      setTimeout(removeIdle, reapInterval);
+      removeIdleScheduled = setTimeout(removeIdle, reapInterval);
+    }
+  }
+
+  /**
+   * Schedule removal of idle items in the pool.
+   *
+   * More schedules cannot run concurrently.
+   */
+  function unscheduleRemoveIdle() {
+    if (removeIdleScheduled) {
+      clearTimeout(removeIdleScheduled);
+      removeIdleScheduled = false;
     }
   }
 
@@ -340,9 +351,23 @@ exports.Pool = function (factory) {
       me.destroy(obj.obj);
       obj = willDie.shift();
     }
-    if (callback) {
+
+    if (callback)
       callback();
-    }
+  };
+
+
+  /**
+   * Simple wrapper to invoke drain followed by destroyAllNow
+   *
+   * @param {Function} callback
+   *   Optional. Callback invoked after all existing clients are destroyed.
+   */
+  me.shutdown = function(callback) {
+    me.drain(function() {
+      unscheduleRemoveIdle();
+      me.destroyAllNow(callback);
+    });
   };
 
   me.getPoolSize = function() {

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -116,7 +116,7 @@ module.exports = {
         });
     },
 
-    'tests drain' : function (beforeExit) {
+    'tests shutdown (drain/destroyAllNow)' : function (beforeExit) {
         var created = 0;
         var destroyed = 0;
         var count = 5;
@@ -139,10 +139,9 @@ module.exports = {
         }
 
         assert.notEqual(count, acquired);
-        pool.drain(function() {
+        // short circuit the absurdly long timeouts above.
+        pool.shutdown(function() {
             assert.equal(count, acquired);
-            // short circuit the absurdly long timeouts above.
-            pool.destroyAllNow();
             beforeExit(function() {});
         });
 
@@ -281,7 +280,7 @@ module.exports = {
         });
     },
 
-    'logPassesLogLevel': function(beforeExit){
+    'logPassesLogLevel': function(beforeExit) {
         var loglevels = {'verbose':0, 'info':1, 'warn':2, 'error':3};
         var logmessages = {verbose:[], info:[], warn:[], error:[]};
         var factory = {


### PR DESCRIPTION
Hi,

As related to #31, I am trying to kill clients when an `.on('error')` hook is invoked. If `destroy()` is called outside of the `acquire()` block (i.e., my client gets a TCP RST during some idle window) then `destroy()` is not sufficient to clean up, as the borked client will still be sitting in `availableObjects`.  This fix simply rewrites that list without the client in question.

Feel free to suggest better ways of doing this - I really just need the functionality, and it's your code, so I can change this to look like whatever you want.

Thanks!
~Mark
