### PR TITLE
Clear remove idle timer after destroyAllNow

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -96,6 +96,7 @@ exports.Pool = function (factory) {
       waitingClients = new PriorityQueue(factory.priorityRange || 1),
       count = 0,
       removeIdleScheduled = false,
+      removeIdleTimer = null,
       draining = false,
 
       // Prepare a logger function.
@@ -176,7 +177,7 @@ exports.Pool = function (factory) {
   function scheduleRemoveIdle() {
     if (!removeIdleScheduled) {
       removeIdleScheduled = true;
-      setTimeout(removeIdle, reapInterval);
+      removeIdleTimer = setTimeout(removeIdle, reapInterval);
     }
   }
 
@@ -343,6 +344,8 @@ exports.Pool = function (factory) {
       me.destroy(obj.obj);
       obj = willDie.shift();
     }
+    removeIdleScheduled = false;
+    clearTimeout(removeIdleTimer);
     if (callback) {
       callback();
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     { "name": "James Cooper", "email": "james@bitmechanic.com" },
     { "name": "Peter Galiba", "email": "poetro@poetro.hu", "url": "http://poetro.hu/" },
     { "name": "Gary Dusbabek" },
-    { "name": "Tom MacWright", "url" : "http://www.developmentseed.org/" }
+    { "name": "Tom MacWright", "url" : "http://www.developmentseed.org/" },
+    { "name": "Douglas Christopher Wilson", "email": "doug@somethingdoug.com", "url" : "http://somethingdoug.com/" }
   ],
   "keywords": ["pool", "pooling", "throttle"],
   "main": "lib/generic-pool.js",


### PR DESCRIPTION
This keeps track of the remove idle timer and will clear the timer when `destroyAllNow` is called, as after all clients are destroyed there is no need to check for idle clients any longer. Without clearing the timer, a program may have called `destroyAllNow` because it was about to exit, but if the remove idle timer still exists,
the event loop will continue running until at most `realIntervalMillis`.

Plus, clearing this timer is just awesome in general, as it prevents unnecessary work.
