### PR TITLE
Adding option to global and local control for adjustCallback

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -55,7 +55,7 @@ var PriorityQueue = function(size) {
   };
 
   return me;
-    }, globalAdjustCallback = true;
+};
 
 /**
  * Generate an Object pool with a specified `factory`.
@@ -103,7 +103,6 @@ exports.Pool = function (factory) {
       removeIdleScheduled = false,
       removeIdleTimer = null,
       draining = false,
-      shouldAdjustCallback = 'adjustCallback' in factory ? factory.adjustCallback : globalAdjustCallback,
 
       // Prepare a logger function.
       log = factory.log ?
@@ -120,10 +119,10 @@ exports.Pool = function (factory) {
 
   factory.max = parseInt(factory.max, 10);
   factory.min = parseInt(factory.min, 10);
-  
+
   factory.max = Math.max(isNaN(factory.max) ? 1 : factory.max, 1);
   factory.min = Math.min(isNaN(factory.min) ? 0 : factory.min, factory.max-1);
-  
+
   ///////////////
 
   /**
@@ -141,7 +140,7 @@ exports.Pool = function (factory) {
               return (objWithTimeout.obj !== obj);
     });
     factory.destroy(obj);
-    
+
     ensureMinimum();
   };
 
@@ -165,7 +164,7 @@ exports.Pool = function (factory) {
         // Client timed out, so destroy it.
         log("removeIdle() destroying obj - now:" + now + " timeout:" + timeout, 'verbose');
         toRemove.push(availableObjects[i].obj);
-      } 
+      }
     }
 
     for (i = 0, tr = toRemove.length; i < tr; i += 1) {
@@ -197,24 +196,6 @@ exports.Pool = function (factory) {
   }
 
   /**
-   * Handle callbacks with either the [obj] or [err, obj] arguments in an
-   * adaptive manner. Uses the `cb.length` property to determine the number
-   * of arguments expected by `cb`.
-   */
-  function adjustCallback(cb, err, obj) {
-    if (!shouldAdjustCallback) {
-        cb(err, obj);
-        return;
-    }
-    if (!cb) return;
-    if (cb.length <= 1) {
-      cb(obj);
-    } else {
-      cb(err, obj);
-    }
-  }
-
-  /**
    * Try to get a new client to work, and clean up pool unused (idle) items.
    *
    *  - If there are available clients waiting, shift the first one out (LIFO),
@@ -229,20 +210,20 @@ exports.Pool = function (factory) {
         objWithTimeout = null,
         err = null,
         waitingCount = waitingClients.size();
-        
+
     log("dispense() clients=" + waitingCount + " available=" + availableObjects.length, 'info');
     if (waitingCount > 0) {
       if (availableObjects.length > 0) {
         log("dispense() - reusing obj", 'verbose');
         objWithTimeout = availableObjects.shift();
-        adjustCallback(waitingClients.dequeue(), err, objWithTimeout.obj);
+		  waitingClients.dequeue()(err, objWithTimeout.obj);
       }
       else if (count < factory.max) {
         createResource();
       }
     }
   }
-  
+
   function createResource() {
     count += 1;
     log("createResource() - creating obj - count=" + count + " min=" + factory.min + " max=" + factory.max, 'verbose');
@@ -257,17 +238,17 @@ exports.Pool = function (factory) {
       }
       if (err) {
         count -= 1;
-        adjustCallback(cb, err, obj);
+        cb(err, obj);
       } else {
         if (cb) {
-          adjustCallback(cb, err, obj);
+          cb(err, obj);
         } else {
           me.release(obj);
         }
       }
     });
   }
-  
+
   function ensureMinimum() {
     var i, diff;
     if (!draining && (count < factory.min)) {
@@ -394,7 +375,7 @@ exports.Pool = function (factory) {
    * Decorates a function to use a acquired client from the object pool when called.
    *
    * @param {Function} decorated
-   *   The decorated function, accepting a client as the first argument and 
+   *   The decorated function, accepting a client as the first argument and
    *   (optionally) a callback as the final argument.
    *
    * @param {Number} priority
@@ -422,7 +403,7 @@ exports.Pool = function (factory) {
             callerCallback.apply(null, arguments);
           }
         });
-        
+
         decorated.apply(null, args);
       }, priority);
     };
@@ -449,18 +430,4 @@ exports.Pool = function (factory) {
   ensureMinimum();
 
   return me;
-};
-
-/**
- * Set or return globalAdjustCallback option that indicate whether adjustCallback for all pools
- * This option can be overwritten ty local pool option "adjustCallback"
- *
- * @param adjust when undefined then return actual value of globalAdjustCallback
- * @return {Boolean}
- */
-exports.Pool.adjustCallback = function (adjust) {
-    if (typeof adjust === 'undefined') {
-        return globalAdjustCallback;
-    }
-    globalAdjustCallback = !!adjust;
 };

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -229,67 +229,6 @@ module.exports = {
         }, Error);
     },
 
-    'supports single arg callbacks' : function (beforeExit) {
-        var pool = poolModule.Pool({
-            name     : 'test5',
-            create   : function(callback) { callback({ id : 1 }); },
-            destroy  : function(client) { destroyed.push(client.id); },
-            max : 2,
-            idleTimeoutMillis : 100
-        });
-
-        pool.acquire(function(client) {
-            assert.equal(client.id, 1);
-        });
-    },
-
-    'ignore callback arguments length when "adjustCallback" option set to false': function () {
-        var pool = poolModule.Pool({
-            name          : 'test1',
-            create        : function(callback) { callback ({id: 2}) },
-            adjustCallback: false
-        });
-
-        pool.acquire(function() {
-            var error = arguments[0],
-                client = arguments[1];
-            assert.equal(error, undefined);
-            assert.equal(client.id, 2);
-        });
-    },
-
-    'ignore callback arguments length when global "adjustCallback" option set to false': function(beforeExit) {
-        poolModule.Pool.adjustCallback(false);
-        var pool = poolModule.Pool({
-            name     : 'test1',
-            create   : function(callback) { callback ({id: 2}) }
-        });
-
-        pool.acquire(function() {
-            var error = arguments[0],
-                client = arguments[1];
-            assert.equal(error, undefined);
-            assert.equal(client.id, 2);
-        });
-        beforeExit(function() {
-            poolModule.Pool.adjustCallback(true);
-        });
-    },
-
-    'global "adjustCallback" can be overwritten by local pool option "adjustCallback"': function() {
-        poolModule.Pool.adjustCallback(false);
-        var pool = poolModule.Pool({
-            name          : 'test1',
-            create        : function(callback) { callback ({id: 2}) },
-            adjustCallback: true
-        });
-
-        pool.acquire(function() {
-            var client = arguments[0];
-            assert.equal(client.id, 2);
-        });
-    },
-
     'handle creation errors' : function (beforeExit) {
         var created = 0;
         var pool = poolModule.Pool({


### PR DESCRIPTION
Before commit

```
pool.Pool({
 name: 'test',
 create: function() { callback({some:'value'}) }
});
pool.acquire(function(client) {
  // passing client/result object as first argument of callback 
  // may confuse flow control modules like node-seq and others
  console.log(client.some); // value
});

```

After commit adjustCallback behavior can be controlled.

```

// local configuration
pool.Pool({
 create: function() { callback({some:'value'}) },
 adjustCallback: false,
 name: 'test'
});
pool.acquire(function(){
  var error = arguments[0], client = arguments[1];
  console.log(error); // undefined
  console.log(client.some); // value
});

// global configuration
pool.Pool.adjustCallback(false);
pool.Pool({
 name: 'test',
 create: function() { callback({some:'value'}) }
});
pool.acquire(function(){
  var error = arguments[0], client = arguments[1];
  console.log(error); // undefined
  console.log(client.some); // value
});

// global flag can be overwritten by local option
pool.Pool.adjustCallback(false);
pool.Pool({
 name: 'test',
 create: function() { callback({some:'value'}) },
 adjustCallback: true
});
pool.acquire(function(client){
  console.log(client.some); // value
});
```
