### PR TITLE
fix global leak

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -241,6 +241,7 @@ exports.Pool = function (factory) {
   }
   
   function createResource() {
+    var err, obj;
     count += 1;
     log("createResource() - creating obj - count=" + count + " min=" + factory.min + " max=" + factory.max, 'verbose');
     factory.create(function () {


### PR DESCRIPTION
Hi

When running global pool as part of a unit test (of another project) using the mocha framework I got this error:

Error: global leaks detected: err, obj

This is the fix.
