### PR TITLE
Fix to empty waiting clients queues in case of an error

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -255,7 +255,10 @@ exports.Pool = function (factory) {
       }
       if (err) {
         count -= 1;
-        clientCb(err, obj);
+        if (clientCb) {
+          clientCb(err, obj);
+        }
+        dispense();
       } else {
         if (clientCb) {
           clientCb(err, obj);

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -252,9 +252,54 @@ module.exports = {
                 assert.ok(client === null);
             });
         }
+        var called = false;
         pool.acquire(function(err, client) {
             assert.ok(err === null);
             assert.equal(typeof client.id, 'number');
+            called = true;
+        });
+        beforeExit(function() {
+            assert.ok(called);
+            assert.equal(pool.waitingClientsCount(), 0);
+        });
+    },
+    
+    'handle creation errors for delayed creates' : function (beforeExit) {
+        var created = 0;
+        var pool = poolModule.Pool({
+            name     : 'test6',
+            create   : function(callback) {
+                if (created < 5) {
+                    setTimeout(function() {
+                        callback(new Error('Error occurred.'));
+                    }, 0);
+                } else {
+                    setTimeout(function() {
+                        callback({ id : created });
+                    }, 0);
+                }
+                created++;
+            },
+            destroy  : function(client) { },
+            max : 1,
+            idleTimeoutMillis : 1000
+        });
+        // ensure that creation errors do not populate the pool.
+        for (var i = 0; i < 5; i++) {
+            pool.acquire(function(err, client) {
+                assert.ok(err instanceof Error);
+                assert.ok(client === null);
+            });
+        }
+        var called = false;
+        pool.acquire(function(err, client) {
+            assert.ok(err === null);
+            assert.equal(typeof client.id, 'number');
+            called = true;
+        });
+        beforeExit(function() {
+            assert.ok(called);
+            assert.equal(pool.waitingClientsCount(), 0);
         });
     },
 


### PR DESCRIPTION
[Resending the pull request with only the changed commit]

If there's an error with creation of a connection we should keep dispensing the waiting clients as long as they exist, otherwise we will only remove one waitingClient from the queue and never go back to other waiting ones.

I created a copy of the "handle creation error" test to show this behaviour. If create doesn't return immediately and it fails although count stays 0, clients will be put on waiting queue and never picked up. That's why on the error callback I called dispense again to check for other waiting requests.
