### PR TITLE
Fix for not removing idle objects

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -165,7 +165,7 @@ exports.Pool = function (factory) {
 
     // Go through the available (idle) items,
     // check if they have timed out
-    for (i = 0, al = availableObjects.length; i < al && (refreshIdle || (count - factory.min)) > toRemove.length ; i += 1) {
+    for (i = 0, al = availableObjects.length; i < al && (refreshIdle || (count - factory.min > toRemove.length)); i += 1) {
       timeout = availableObjects[i].timeout;
       if (now >= timeout) {
         // Client timed out, so destroy it.


### PR DESCRIPTION
Before my change, for-loop execute only once.
Let's simplify this part of condition:

(refreshIdle || (count - factory.min)) > toRemove.length

true || NUMBER > toRemove.length
true > toRemove.length

and if toRemove.length = 0
true > 0
true > false  -> true

but if toRemove.length = 1
true > 1
true > true -> false

And examples:
- before http://jsfiddle.net/mBbM7/
- after http://jsfiddle.net/nXWys/1/
