### PR TITLE
Api consistency between acquire and release

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -123,13 +123,13 @@ exports.Pool = function (factory) {
         function () {};
 
   factory.validate = factory.validate || function() { return true; };
-        
+
   factory.max = parseInt(factory.max, 10);
   factory.min = parseInt(factory.min, 10);
-  
+
   factory.max = Math.max(isNaN(factory.max) ? 1 : factory.max, 1);
   factory.min = Math.min(isNaN(factory.min) ? 0 : factory.min, factory.max-1);
-  
+
   ///////////////
 
   /**
@@ -147,7 +147,7 @@ exports.Pool = function (factory) {
               return (objWithTimeout.obj !== obj);
     });
     factory.destroy(obj);
-    
+
     ensureMinimum();
   };
 
@@ -171,7 +171,7 @@ exports.Pool = function (factory) {
         // Client timed out, so destroy it.
         log("removeIdle() destroying obj - now:" + now + " timeout:" + timeout, 'verbose');
         toRemove.push(availableObjects[i].obj);
-      } 
+      }
     }
 
     for (i = 0, tr = toRemove.length; i < tr; i += 1) {
@@ -232,7 +232,7 @@ exports.Pool = function (factory) {
         err = null,
         clientCb = null,
         waitingCount = waitingClients.size();
-        
+
     log("dispense() clients=" + waitingCount + " available=" + availableObjects.length, 'info');
     if (waitingCount > 0) {
       while (availableObjects.length > 0) {
@@ -251,7 +251,7 @@ exports.Pool = function (factory) {
       }
     }
   }
-  
+
   function createResource() {
     count += 1;
     log("createResource() - creating obj - count=" + count + " min=" + factory.min + " max=" + factory.max, 'verbose');
@@ -282,7 +282,7 @@ exports.Pool = function (factory) {
       }
     });
   }
-  
+
   function ensureMinimum() {
     var i, diff;
     if (!draining && (count < factory.min)) {
@@ -328,10 +328,12 @@ exports.Pool = function (factory) {
    * @param {Object} obj
    *   The acquired object to be put back to the pool.
    */
-  me.release = function (obj) {
+  me.release = function (obj, callback) {
 	// check to see if this object has already been released (i.e., is back in the pool of availableObjects)
     if (availableObjects.some(function(objWithTimeout) { return (objWithTimeout.obj === obj); })) {
-      log("release called twice for the same resource: " + (new Error().stack), 'error');
+      var error = new Error('release called twice for the same resource');
+      log(error.stack, 'error');
+      if (callback) callback(error);
       return;
     }
     //log("return to pool");
@@ -340,6 +342,7 @@ exports.Pool = function (factory) {
     log("timeout: " + objWithTimeout.timeout, 'verbose');
     dispense();
     scheduleRemoveIdle();
+    if (callback) callback();
   };
 
   me.returnToPool = function (obj) {
@@ -409,7 +412,7 @@ exports.Pool = function (factory) {
    * Decorates a function to use a acquired client from the object pool when called.
    *
    * @param {Function} decorated
-   *   The decorated function, accepting a client as the first argument and 
+   *   The decorated function, accepting a client as the first argument and
    *   (optionally) a callback as the final argument.
    *
    * @param {Number} priority
@@ -437,7 +440,7 @@ exports.Pool = function (factory) {
             callerCallback.apply(null, arguments);
           }
         });
-        
+
         decorated.apply(null, args);
       }, priority);
     };


### PR DESCRIPTION
Makes the API between `acquire` and `release` a bit more consistent (both accepting callbacks), adding an optional callback for release, notifying the callback if it has been called multiple times for the same connection.
