### PR TITLE
Change default priority to size - 1

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -23,8 +23,8 @@ var PriorityQueue = function(size) {
   me.enqueue = function (obj, priority) {
     var priorityOrig;
 
-    // Convert to integer with a default value of 0.
-    priority = priority && + priority | 0 || 0;
+    // Convert to integer with a default value of size - 1 (lowest priority).
+    priority = (priority !== undefined) ? + priority | 0 : size - 1;
 
     // Clear cache for total.
     total = null;


### PR DESCRIPTION
README.md states that the default priority is "no priority - will go at end of line" yet the implementation was setting the default priority to 0 which puts them at the front of the line.