### PR TITLE
Added promise-based acquisition method.

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -461,17 +461,27 @@ exports.Pool = function (factory) {
    * @param {Function} callback
    *   Callback function to be called after the acquire is successful.
    *   The function will receive the acquired item as the first parameter and must
-   *   return a promise.
+   *   return a promise or accept a callback as the second parameter.
    *
    * @param {Number} priority
    *   Optional.  Integer between 0 and (priorityRange - 1).  Specifies the priority
    *   of the caller if there are no available resources.  Lower numbers mean higher
    *   priority.
    *
-   * @returns {Promise}
+   * @param {Function} done
+   *   Optional.  Callback function to be called after the client is released. If not
+   *   provided, a Promise will be returned instead.
+   *
+   * @returns {?Promise} If no `done` callback is provided, a promise for the results is returned.
    */
-  me.acquirePromise = function(callback, priority) {
-    return new Promise(function(resolve, reject) {
+  me.safeAcquire = function(callback, priority, done) {
+    // Juggle the parameters since both priority and done are independently optional.
+    if(priority && priority instanceof Function) {
+      done = priority;
+      priority = null;
+    }
+
+    var safeAcquisition = function(resolve, reject){
       me.acquire(function(err, client) {
         if(err) {
           reject(err);
@@ -479,20 +489,41 @@ exports.Pool = function (factory) {
         }
 
         try {
-          // Call back with the client, and then rain or shine, release the client.
-          callback(client).then(
-            function(res){ me.release(client); resolve(res); },
-            function(err){ me.release(client); reject(err); }
-          );
+          // Call back with the acquired client, checking if we're working with Promise-style or
+          // callback style.
+          if(callback.length == 1) {
+            callback(client).then(
+              function(res){ me.release(client); resolve(res); },
+              function(err){ me.release(client); reject(err); }
+            );
+          }
+          else {
+            callback(client, function(err, res){
+              if(err) {
+                reject(err);
+              }
+              else {
+                resolve(res);
+              }
+            });
+          }
         }
         catch(err) {
           // Even if the callback throws, release the client.
           me.release(client);
           reject(err);
         }
-      });
-    });
+      }, priority);
+    };
+
+    if(done) {
+      safeAcquisition(function(res){ done(null, res); }, done);
+    }
+    else {
+      return new Promise(safeAcquisition);
+    }
   };
+
 
   me.getPoolSize = function() {
     return count;

--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -126,13 +126,13 @@ exports.Pool = function (factory) {
         function () {};
 
   factory.validate = factory.validate || function() { return true; };
-        
+
   factory.max = parseInt(factory.max, 10);
   factory.min = parseInt(factory.min, 10);
-  
+
   factory.max = Math.max(isNaN(factory.max) ? 1 : factory.max, 1);
   factory.min = Math.min(isNaN(factory.min) ? 0 : factory.min, factory.max-1);
-  
+
   ///////////////
 
   /**
@@ -150,7 +150,7 @@ exports.Pool = function (factory) {
               return (objWithTimeout.obj !== obj);
     });
     factory.destroy(obj);
-    
+
     ensureMinimum();
   };
 
@@ -174,7 +174,7 @@ exports.Pool = function (factory) {
         // Client timed out, so destroy it.
         log("removeIdle() destroying obj - now:" + now + " timeout:" + timeout, 'verbose');
         toRemove.push(availableObjects[i].obj);
-      } 
+      }
     }
 
     for (i = 0, tr = toRemove.length; i < tr; i += 1) {
@@ -235,7 +235,7 @@ exports.Pool = function (factory) {
         err = null,
         clientCb = null,
         waitingCount = waitingClients.size();
-        
+
     log("dispense() clients=" + waitingCount + " available=" + availableObjects.length, 'info');
     if (waitingCount > 0) {
       while (availableObjects.length > 0) {
@@ -254,7 +254,7 @@ exports.Pool = function (factory) {
       }
     }
   }
-  
+
   function createResource() {
     count += 1;
     log("createResource() - creating obj - count=" + count + " min=" + factory.min + " max=" + factory.max, 'verbose');
@@ -285,7 +285,7 @@ exports.Pool = function (factory) {
       }
     });
   }
-  
+
   function ensureMinimum() {
     var i, diff;
     if (!draining && (count < factory.min)) {
@@ -340,11 +340,11 @@ exports.Pool = function (factory) {
     //log("return to pool");
     var objWithTimeout = { obj: obj, timeout: (new Date().getTime() + idleTimeoutMillis) };
     if(returnToHead){
-      availableObjects.splice(0, 0, objWithTimeout);      
+      availableObjects.splice(0, 0, objWithTimeout);
     }
     else{
-      availableObjects.push(objWithTimeout);  
-    }    
+      availableObjects.push(objWithTimeout);
+    }
     log("timeout: " + objWithTimeout.timeout, 'verbose');
     dispense();
     scheduleRemoveIdle();
@@ -414,10 +414,10 @@ exports.Pool = function (factory) {
   };
 
   /**
-   * Decorates a function to use a acquired client from the object pool when called.
+   * Decorates a function to use an acquired client from the object pool when called.
    *
    * @param {Function} decorated
-   *   The decorated function, accepting a client as the first argument and 
+   *   The decorated function, accepting a client as the first argument and
    *   (optionally) a callback as the final argument.
    *
    * @param {Number} priority
@@ -445,10 +445,53 @@ exports.Pool = function (factory) {
             callerCallback.apply(null, arguments);
           }
         });
-        
+
         decorated.apply(null, args);
       }, priority);
     };
+  };
+
+  /**
+   * Acquires a client and releases it automatically when the callback is done with it.
+   *
+   * When the callback resolves or rejects the promise it returned the acquired client
+   * is released to the pool again and the result is propagated through this method's
+   * promise.
+   *
+   * @param {Function} callback
+   *   Callback function to be called after the acquire is successful.
+   *   The function will receive the acquired item as the first parameter and must
+   *   return a promise.
+   *
+   * @param {Number} priority
+   *   Optional.  Integer between 0 and (priorityRange - 1).  Specifies the priority
+   *   of the caller if there are no available resources.  Lower numbers mean higher
+   *   priority.
+   *
+   * @returns {Promise}
+   */
+  me.acquirePromise = function(callback, priority) {
+    return new Promise(function(resolve, reject) {
+      me.acquire(function(err, client) {
+        if(err) {
+          reject(err);
+          return;
+        }
+
+        try {
+          // Call back with the client, and then rain or shine, release the client.
+          callback(client).then(
+            function(res){ me.release(client); resolve(res); },
+            function(err){ me.release(client); reject(err); }
+          );
+        }
+        catch(err) {
+          // Even if the callback throws, release the client.
+          me.release(client);
+          reject(err);
+        }
+      });
+    });
   };
 
   me.getPoolSize = function() {


### PR DESCRIPTION
This pull request is incomplete (missing tests) but I wanted to get feedback and find out if you are at all open to the idea before spending too much time on it.

The basic idea is that by using ES6 promises (which are in Node 0.12) you can make the release of acquired clients automatic. This is something I've built into my own projects as a layer on top of generic-pool, and I felt it could be a nice addition to the package.

Example with promise-based client:
```js
var pool = Pool({ /* ... */ });

pool.safeAcquire(function(client){
    return client.getSomething('foobar')
        .then(function(something){
            console.dir(something);
            return 'Yay, done!';
        });
}).then(function(result){
    // The client has been released.
    console.log('Got a result:', result);
}).catch(function(error){
    // Even if there had been an error, the client would have been released.
    console.error('Got an error:', error);
});
```

Alternately, if you prefer callback chains:
```js
pool.safeAcquire(function(client, releaseClient){
    client.getSomething('foobar', function(err, something){
        if(err) {
            releaseClient(err);
        }
        else {
            console.dir(something);
            releaseClient(null, 'Yay, done!');
        }
    });
}, function(err, result){
    // The client has been released before this method is called.
    if(err) {
        console.error('Got an error:', err);
    }
    else {
        console.log('Got a result:', result);
    }
});
```

Note that there is no explicit `release` in that code, but the client is released nonetheless. This removes the possibility of the programmer simply forgetting to release, or not handling some error case correctly making it safer than a simple `acquire`.

Outstanding questions:
 - How to test it? Should be straightforward, but I haven't looked at your test structure yet.
 - ~~When did Node get the `Promise` class? This may affect the package's `engines` requirement.~~ Node version 0.11.14 was the first with `Promise`.
 - ~~What is a better name? `acquirePromise` is terrible, hoping someone can come up with something better.~~ Changed to `safeAcquire`.

P.S. Sorry for the spurious whitespace removal in this commit, Atom doesn't like trailing whitespace. :)