### PR TITLE
Release validation

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -105,6 +105,7 @@ exports.Pool = function (factory) {
       reapInterval = factory.reapIntervalMillis || 1000,
       refreshIdle = ('refreshIdle' in factory) ? factory.refreshIdle : true,
       availableObjects = [],
+      inUseObjects = [],
       waitingClients = new PriorityQueue(factory.priorityRange || 1),
       count = 0,
       removeIdleScheduled = false,
@@ -150,6 +151,11 @@ exports.Pool = function (factory) {
     availableObjects = availableObjects.filter(function(objWithTimeout) {
               return (objWithTimeout.obj !== obj);
     });
+
+    inUseObjects = inUseObjects.filter(function(obj) {
+              return (obj !== obj);
+    });
+
     factory.destroy(obj);
     
     ensureMinimum();
@@ -247,6 +253,7 @@ exports.Pool = function (factory) {
           continue;
         }
         availableObjects.shift();
+        inUseObjects.push(objWithTimeout.obj);
         clientCb = waitingClients.dequeue();
         return clientCb(err, objWithTimeout.obj);
       }
@@ -279,6 +286,7 @@ exports.Pool = function (factory) {
           dispense();
         });
       } else {
+        inUseObjects.push(obj);
         if (clientCb) {
           clientCb(err, obj);
         } else {
@@ -334,19 +342,28 @@ exports.Pool = function (factory) {
    *   The acquired object to be put back to the pool.
    */
   me.release = function (obj) {
-	// check to see if this object has already been released (i.e., is back in the pool of availableObjects)
+    // check to see if this object has already been released (i.e., is back in the pool of availableObjects)
     if (availableObjects.some(function(objWithTimeout) { return (objWithTimeout.obj === obj); })) {
       log("release called twice for the same resource: " + (new Error().stack), 'error');
       return;
     }
+
+    // check to see if this object exists in the `in use` list and remove it
+    var index = inUseObjects.indexOf(obj);
+    if (index < 0) {
+      log("attempt to release an invalid resource: " + (new Error().stack), 'error');
+      return;
+    }
+
     //log("return to pool");
+    inUseObjects.splice(index, 1);
     var objWithTimeout = { obj: obj, timeout: (new Date().getTime() + idleTimeoutMillis) };
     if(returnToHead){
-      availableObjects.splice(0, 0, objWithTimeout);      
+      availableObjects.splice(0, 0, objWithTimeout);
     }
     else{
-      availableObjects.push(objWithTimeout);  
-    }    
+      availableObjects.push(objWithTimeout);
+    }
     log("timeout: " + objWithTimeout.timeout, 'verbose');
     dispense();
     scheduleRemoveIdle();
@@ -465,13 +482,17 @@ exports.Pool = function (factory) {
     return availableObjects.length;
   };
 
+  me.inUseObjectsCount = function() {
+    return inUseObjects.length;
+  };
+
   me.waitingClientsCount = function() {
     return waitingClients.size();
   };
 
   me.getMaxPoolSize = function(){
     return factory.max;
-  }
+  };
 
   // create initial resources (if factory.min > 0)
   ensureMinimum();

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -613,7 +613,34 @@ module.exports = {
        beforeExit(function() {
          assert.equal(getFlag, 1);   
        });
+    },
+
+    'returns only valid object to the pool': function(beforeExit){
+        var pool = poolModule.Pool({
+            name: 'test',
+            create: function(callback) {
+                process.nextTick(function(){
+                    callback(null, { id: 'validId' });
+                });
+            },
+            destroy: function(client) {},
+            max: 1,
+            idleTimeoutMillis: 100
+        });
+
+        pool.acquire(function(err, obj){
+            assert.equal(pool.availableObjectsCount(), 0);
+            assert.equal(pool.inUseObjectsCount(), 1);
+
+            // Invalid release
+            pool.release({});
+            assert.equal(pool.availableObjectsCount(), 0);
+            assert.equal(pool.inUseObjectsCount(), 1);
+
+            // Valid release
+            pool.release(obj);
+            assert.equal(pool.availableObjectsCount(), 1);
+            assert.equal(pool.inUseObjectsCount(), 0);
+        });
     }
-
-
 };


### PR DESCRIPTION
The current implementation of `release()` allows pushing any arbitrary object to the pool without any validation. This behavior makes subsequent calls to `acquire()` fail. Consider this example:

    var pool = poolModule.Pool(factory);
    pool.release(undefined);
    pool.acquire(function(err, obj) {
      obj.doSomething(); // Uncaught TypeError: Cannot call method 'doSomething' of undefined
    });

This PR fixes that behavior by using an `inUseObjects` list and check for valid objects inside the list when calling `release()`.