### PR TITLE
Fix refreshIdle and min size check in _removeIdle

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -211,7 +211,7 @@ Pool.prototype._removeIdle = function removeIdle () {
 
   // Go through the available (idle) items,
   // check if they have timed out
-  for (i = 0, al = this._availableObjects.length; i < al && (this._factory.refreshIdle || (this._count - this._factory.min > toRemove.length)); i += 1) {
+  for (i = 0, al = this._availableObjects.length; i < al && (this._factory.refreshIdle && (this._count - this._factory.min > toRemove.length)); i += 1) {
     timeout = this._availableObjects[i].timeout
     if (now >= timeout) {
       // Client timed out, so destroy it.

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -55,7 +55,10 @@ module.exports = {
       max: 2,
       idleTimeoutMillis: 100
     })
-    pool.drain()
+
+    pool.drain(function () {
+      pool.destroyAllNow()
+    })
 
     beforeExit(function () {
       assert.equal(0, pool.availableObjectsCount())
@@ -106,7 +109,9 @@ module.exports = {
       max: 3
     }
     var pool = poolModule.Pool(factory)
-    pool.drain()
+    pool.drain(function () {
+      pool.destroyAllNow();
+    })
 
     beforeExit(function () {
       assert.equal(3, pool.getMaxPoolSize())


### PR DESCRIPTION
Prior to this patch, a `true` value for `refreshIdle` (the default) would cause all objects in a pool to be eligible for destruction in `_removeIdle`, regardless of the min pool size. Likewise, a `false` value for `refreshIdle` (intended to prevent idle object culling) would be ignored as long as the min size check passed.