### PR TITLE
Add Make targets for common commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,21 @@
+.PHONY: all clean install check test lint-install lint
+
 all:
+
+clean:
+	rm -rf node_modules
+
+install:
+	npm install
 
 check:
 	npm test
+
+test:
+	npm test
+
+lint-install:
+	npm run lint-install
+
+lint:
+	npm run lint

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "lint": "eslint lib test",
     "lint-install": "npm install eslint@^1.10.2 eslint-config-standard@^4.4.0 eslint-plugin-standard@^1.3.1" ,
-    "test": "expresso -I lib test/*.js"
+    "test": "expresso test/*.js"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This adds Make targets for common tasks:

- clean: remove installed project files
- test-install: install test dependencies
- test: run the tests
- lint: run the linter

I believe the README may be incorrect, since "npm install" installs into the
`node_modules` repo, but `npm test` etc may be counting on the global name
space.