### PR TITLE
Add option to error if the pool is full

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -364,24 +364,36 @@ Pool.prototype._ensureMinimum = function _ensureMinimum () {
   }
 }
 
+Pool.prototype._isFull = function() {
+  return this._count >= this._factory.max && this._availableObjects.length === 0
+}
+
 /**
  * Request a new client. The callback will be called,
- * when a new client will be availabe, passing the client to it.
+ * when a new client will be available, passing the client to it.
  *
  * @param {Function} callback
  *   Callback function to be called after the acquire is successful.
  *   The function will receive the acquired item as the first parameter.
  *
  * @param {Number} priority
- *   Optional.  Integer between 0 and (priorityRange - 1).  Specifies the priority
- *   of the caller if there are no available resources.  Lower numbers mean higher
- *   priority.
+ *   Optional. Integer between 0 and (priorityRange - 1). Specifies the
+ *   priority of the caller if there are no available resources. Lower numbers
+ *   mean higher priority.
+ *
+ * @param {Object} options
+ *   Optional. If `options.block` is `false`, immediately return an error if
+ *   no space is available in the queue.
  *
  * @returns {boolean} `true` if the pool is not fully utilized, `false` otherwise.
  */
-Pool.prototype.acquire = function acquire (callback, priority) {
+Pool.prototype.acquire = function acquire (callback, priority, options) {
   if (this._draining) {
     throw new Error('pool is draining and cannot accept work')
+  }
+  if (options !== null && typeof options !== "undefined" && options.block === false && this._isFull()) {
+    callback(new Error('Cannot acquire connection because the pool is full'))
+    return false
   }
   this._waitingClients.enqueue(callback, priority)
   this._dispense()


### PR DESCRIPTION
Currently, if you attempt to acquire a resource and the pool is full, the
callback will not run until a space becomes available. This can lead to a
deadlock if a pool member's release is blocked on the acquire callback running.

To mitigate the deadlock possibility, support a third argument
`pool.acquire(cb, priority, {block: false})`, which will immediately hit the
callback with an error if the pool is full. Adds a test that this behaves as
expected.

Callers may want to wait for a small amount of time before giving up on the
pool; I'm going to add that option in a second commit.

This work was sponsored by [Shyp](https://shyp.com).