### PR TITLE
Add lint checks to the Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ node_js:
   - "4"
   - "5"
 
+install:
+  - make install
+  - make lint-install
+
+script:
+  - make lint
+  - make test
+
 sudo: false
 
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all clean install check test lint-install lint
 
+INCOMPATIBLE_ESLINT_VERSIONS=$(shell node --version | egrep 'v0.[2-9]' | cut -d '.' -f 1-2)
+
 all:
 
 clean:
@@ -15,7 +17,15 @@ test:
 	npm test
 
 lint-install:
+ifeq ($(INCOMPATIBLE_ESLINT_VERSIONS),)
 	npm run lint-install
+else
+	@echo "Lint not available on $(INCOMPATIBLE_ESLINT_VERSIONS)"
+endif
 
 lint:
+ifeq ($(INCOMPATIBLE_ESLINT_VERSIONS),)
 	npm run lint
+else
+	@echo "Lint not available on $(INCOMPATIBLE_ESLINT_VERSIONS)"
+endif

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -110,7 +110,7 @@ module.exports = {
     }
     var pool = poolModule.Pool(factory)
     pool.drain(function () {
-      pool.destroyAllNow();
+      pool.destroyAllNow()
     })
 
     beforeExit(function () {


### PR DESCRIPTION
This will fail new builds/PR's if they fail to conform to the style guide.
Fixes the one line that was not conforming to the style guide.

If you `npm run` a command, `npm` prints a big long spiel to the
command line about how it's not responsible for the failure (example:
https://travis-ci.org/Shyp/node-pool/jobs/111683457#L566). We may want to just
run the commands directly (via `./node_modules/.bin/eslint ...`) instead of
calling `npm run`.