### PR TITLE
drain should be async always

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -460,7 +460,7 @@ Pool.prototype.drain = function drain (callback) {
       // wait until all objects have been released.
       setTimeout(check, 100)
     } else if (callback) {
-      callback()
+      process.nextTick(callback)
     }
   }
   check()


### PR DESCRIPTION
The drain function should always invoke the callback asynchronously.
As it is, if the the first two conditions are not satisfied, then the callback
will be executed synchronously.
