### PR TITLE
fix destroy must have a callback

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -178,8 +178,10 @@ Pool.prototype._log = function log (str, level) {
  *
  * @param {Object} obj
  *   The acquired item to be destoyed.
+ * @param {Function} callback
+ *   Optional. Callback invoked after client is destroyed.
  */
-Pool.prototype.destroy = function destroy (obj) {
+Pool.prototype.destroy = function destroy (obj, cb) {
   this._count -= 1
   if (this._count < 0) this._count = 0
   this._availableObjects = this._availableObjects.filter(function (objWithTimeout) {
@@ -190,7 +192,12 @@ Pool.prototype.destroy = function destroy (obj) {
     return (objInUse !== obj)
   })
 
-  this._factory.destroy(obj)
+  this._factory.destroy(obj, cb)
+
+  // keep compatibily with old interface
+  if (this._factory.destroy.length === 1 && cb) {
+    cb()
+  }
 
   this._ensureMinimum()
 }
@@ -483,16 +490,20 @@ Pool.prototype.destroyAllNow = function destroyAllNow (callback) {
   this._log('force destroying all objects', 'info')
   var willDie = this._availableObjects
   this._availableObjects = []
+  var todo = willDie.length
+  var done = 0
   var obj = willDie.shift()
   while (obj !== null && obj !== undefined) {
-    this.destroy(obj.obj)
+    this.destroy(obj.obj, function () {
+      ++done
+      if (done === todo && callback) {
+        callback()
+      }
+    })
     obj = willDie.shift()
   }
   this._removeIdleScheduled = false
   clearTimeout(this._removeIdleTimer)
-  if (callback) {
-    callback()
-  }
 }
 
 /**


### PR DESCRIPTION
Also destroyAllNow should use it and not just call the callback sync.
Added two test, one with the new functionality, one to keep the old one.

All test pass :smile: 
