### PR TITLE
Fix validateAsync usage

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -276,16 +276,21 @@ Pool.prototype._dispense = function dispense () {
       }, function (next) {
         self._log('dispense() - reusing obj', 'verbose')
         objWithTimeout = self._availableObjects[0]
+        self._availableObjects.shift()
+        self._inUseObjects.push(objWithTimeout.obj)
 
         self._factory.validateAsync(objWithTimeout.obj, function (valid) {
           if (!valid) {
             self.destroy(objWithTimeout.obj)
             next()
           } else {
-            self._availableObjects.shift()
-            self._inUseObjects.push(objWithTimeout.obj)
             clientCb = self._waitingClients.dequeue()
-            clientCb(err, objWithTimeout.obj)
+
+            if ( clientCb ) {
+                clientCb(err, objWithTimeout.obj)
+            } else {
+                self.release(objWithTimeout.obj)
+            }
           }
         })
       }, function () {

--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -286,10 +286,10 @@ Pool.prototype._dispense = function dispense () {
           } else {
             clientCb = self._waitingClients.dequeue()
 
-            if ( clientCb ) {
-                clientCb(err, objWithTimeout.obj)
+            if (clientCb) {
+              clientCb(err, objWithTimeout.obj)
             } else {
-                self.release(objWithTimeout.obj)
+              self.release(objWithTimeout.obj)
             }
           }
         })

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -750,7 +750,7 @@ module.exports = {
   },
 
   'validateAsync multiple calls': function (beforeExit) {
-    var create_count = 0;
+    var create_count = 0
 
     var pool = poolModule.Pool({
       name: 'test',
@@ -761,52 +761,52 @@ module.exports = {
         }, 50)
       },
       validateAsync: function (resource, callback) {
-          //console.log( "setTimeout Validate object count:", resource.count )
-          setTimeout(function () {
-              //console.log( "Validating object count:", resource.count )
-              callback(true)
-          }, 100)
+          // console.log( "setTimeout Validate object count:", resource.count )
+        setTimeout(function () {
+          // console.log( "Validating object count:", resource.count )
+          callback(true)
+        }, 100)
       },
       destroy: function (client) {},
       max: 3,
-      idleTimeoutMillis: 100,
-      //log: true
+      idleTimeoutMillis: 100
+      // log: true
     })
 
-    var acquire_release = function( num, in_use_count, available_count, release_timeout ) {
-        release_timeout = release_timeout || 500
-        in_use_count = in_use_count === undefined ? 3 : in_use_count
-        available_count = available_count === undefined ? 0 : available_count
+    var acquire_release = function (num, in_use_count, available_count, release_timeout) {
+      release_timeout = release_timeout || 500
+      in_use_count = in_use_count === undefined ? 3 : in_use_count
+      available_count = available_count === undefined ? 0 : available_count
 
-        pool.acquire(function (err, obj) {
-          //console.log( "Acquire " + num + " - object count:", obj.count )
-          assert.ifError(err)
-          assert.equal(pool.availableObjectsCount(), available_count)
-          assert.equal(pool.inUseObjectsCount(), in_use_count)
-          assert.ok(create_count <= 3)
+      pool.acquire(function (err, obj) {
+        // console.log( "Acquire " + num + " - object count:", obj.count )
+        assert.ifError(err)
+        assert.equal(pool.availableObjectsCount(), available_count)
+        assert.equal(pool.inUseObjectsCount(), in_use_count)
+        assert.ok(create_count <= 3)
 
-          setTimeout( function() {
-             //console.log( "Release " + num + " - object count:", obj.count )
-             pool.release(obj)
-          }, release_timeout )
-        })
-    };
+        setTimeout(function () {
+          // console.log( "Release " + num + " - object count:", obj.count )
+          pool.release(obj)
+        }, release_timeout)
+      })
+    }
 
-    acquire_release( 1, 1 )
-    acquire_release( 2, 2 )
-    acquire_release( 3 )
-    acquire_release( 4 )
+    acquire_release(1, 1)
+    acquire_release(2, 2)
+    acquire_release(3)
+    acquire_release(4)
 
-    setTimeout( function() {
-        acquire_release( 4 )
-        acquire_release( 5 )
-        acquire_release( 6 )
-        acquire_release( 7 )
-        acquire_release( 8, 3, 0, 50 )
-        acquire_release( 9, 3, 0, 50 )
-        acquire_release( 10, 3, 0, 50 )
-        acquire_release( 11 )
-        acquire_release( 12 )
-    }, 1000 )
+    setTimeout(function () {
+      acquire_release(4)
+      acquire_release(5)
+      acquire_release(6)
+      acquire_release(7)
+      acquire_release(8, 3, 0, 50)
+      acquire_release(9, 3, 0, 50)
+      acquire_release(10, 3, 0, 50)
+      acquire_release(11)
+      acquire_release(12)
+    }, 1000)
   }
 }

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -747,5 +747,66 @@ module.exports = {
       assert.equal(pool.availableObjectsCount(), 0)
       assert.equal(pool.inUseObjectsCount(), 1)
     })
+  },
+
+  'validateAsync multiple calls': function (beforeExit) {
+    var create_count = 0;
+
+    var pool = poolModule.Pool({
+      name: 'test',
+      create: function (callback) {
+        setTimeout(function () {
+          create_count += 1
+          callback(null, { id: 'validId', count: create_count })
+        }, 50)
+      },
+      validateAsync: function (resource, callback) {
+          //console.log( "setTimeout Validate object count:", resource.count )
+          setTimeout(function () {
+              //console.log( "Validating object count:", resource.count )
+              callback(true)
+          }, 100)
+      },
+      destroy: function (client) {},
+      max: 3,
+      idleTimeoutMillis: 100,
+      //log: true
+    })
+
+    var acquire_release = function( num, in_use_count, available_count, release_timeout ) {
+        release_timeout = release_timeout || 500
+        in_use_count = in_use_count === undefined ? 3 : in_use_count
+        available_count = available_count === undefined ? 0 : available_count
+
+        pool.acquire(function (err, obj) {
+          //console.log( "Acquire " + num + " - object count:", obj.count )
+          assert.ifError(err)
+          assert.equal(pool.availableObjectsCount(), available_count)
+          assert.equal(pool.inUseObjectsCount(), in_use_count)
+          assert.ok(create_count <= 3)
+
+          setTimeout( function() {
+             //console.log( "Release " + num + " - object count:", obj.count )
+             pool.release(obj)
+          }, release_timeout )
+        })
+    };
+
+    acquire_release( 1, 1 )
+    acquire_release( 2, 2 )
+    acquire_release( 3 )
+    acquire_release( 4 )
+
+    setTimeout( function() {
+        acquire_release( 4 )
+        acquire_release( 5 )
+        acquire_release( 6 )
+        acquire_release( 7 )
+        acquire_release( 8, 3, 0, 50 )
+        acquire_release( 9, 3, 0, 50 )
+        acquire_release( 10, 3, 0, 50 )
+        acquire_release( 11 )
+        acquire_release( 12 )
+    }, 1000 )
   }
 }


### PR DESCRIPTION
When calling acquire multiple times in a row, the async validation would dispense the first object to all callers.

This commit fixes that by removing the object before validating it.

I'm also adding a verification to check if `clientCb` is valid before using it, because we may reach the
validation phase twice even if there is only one waiting client, and therefore we would end up with a null `clientCb`.

There is another way that we could avoid the `clientCb` being null: we could `dequeue` it just before calling `doWhileAsync`. Since this would happen just after verifying the queue size, we would be sure it wouldn't be null. However, if we then reached the point where a resource needs to be created, we would need to add the `clientCb` to the queue again before calling `_createResource`, or we could modify the `_createResource` to accept an optional argument that is the `clientCb`.

The downside of the way I did it is that the validateAsync function may called more times than necessary. The downside of re-adding an item to the queue is that it would be strangely reordered (also I didn't think this through to see if it would result in some problem). The downside of modifying `_createResource` is that we would need to interfere with other internal functions without the need to do so (I also wasn't totally convinced that this would solve the problem without causing trouble elsewhere).

I'll be implementing the other options soon and will post a link to them in the comments here, so that we can better compare then.
