### PR TITLE
make doWhileAsync really async and avoid stack overflow

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -65,7 +65,9 @@ PriorityQueue.prototype.dequeue = function dequeue (callback) {
 function doWhileAsync (conditionFn, iterateFn, callbackFn) {
   var next = function () {
     if (conditionFn()) {
-      iterateFn(next)
+      process.nextTick(function () {
+        iterateFn(next)
+      })
     } else {
       callbackFn()
     }


### PR DESCRIPTION
Sample to fail the original code with `RangeError: Maximum call stack size exceeded`:
```node
global._doWhileAsyncCount=0;
doWhileAsync(
  () => global._doWhileAsyncCount < 1000000,
  (next) => { global._doWhileAsyncCount++; next(); },
  () => {console.log("done");
});
```
Plus this allows `doWhileAsync` to be really async and to return execution before `callbackFn` call (in case when we have at least 1 additional iteration).