### PR TITLE
don't call _scheduleRemoveIdle if refreshIdle is falsy

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -211,7 +211,7 @@ Pool.prototype._removeIdle = function removeIdle () {
 
   // Go through the available (idle) items,
   // check if they have timed out
-  for (i = 0, al = this._availableObjects.length; i < al && (this._factory.refreshIdle && (this._count - this._factory.min > toRemove.length)); i += 1) {
+  for (i = 0, al = this._availableObjects.length; i < al && (this._count - this._factory.min > toRemove.length); i += 1) {
     timeout = this._availableObjects[i].timeout
     if (now >= timeout) {
       // Client timed out, so destroy it.
@@ -427,7 +427,7 @@ Pool.prototype.release = function release (obj) {
   }
   this._log('timeout: ' + objWithTimeout.timeout, 'verbose')
   this._dispense()
-  this._scheduleRemoveIdle()
+  if (this._factory.refreshIdle) this._scheduleRemoveIdle()
 }
 
 /**


### PR DESCRIPTION
Avoids spending unnecessary time in `Pool.prototype._scheduleRemoveIdle` and `Pool.prototype._removeIdle` when idle objects will never be removed.
