### PR TITLE
Use domain.bind to preserve domain context

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -384,6 +384,9 @@ Pool.prototype.acquire = function acquire (callback, priority) {
   if (this._draining) {
     throw new Error('pool is draining and cannot accept work')
   }
+  if (process.domain) {
+    callback = process.domain.bind(callback)
+  }
   this._waitingClients.enqueue(callback, priority)
   this._dispense()
   return (this._count < this._factory.max)


### PR DESCRIPTION
This is a case of the [userland queueing problem](https://docs.google.com/document/d/1tlQ0R6wQFGqCS5KeIw0ddoLbaSYx6aU7vyXOkv-wvlM/edit#heading=h.fy8dcsgxet4l). We don't have automatic implicit binding here, so we need to do explicit binding, as described in the [domain docs](https://nodejs.org/api/domain.html#domain_implicit_binding).

I'm aware that domains are deprecated, people should avoid using them, a replacement is coming, etc, but there are use cases where they are absolutely necessary and losing the domain context can lead to state mismatches. This fix will be helpful for any projects that use node-pool (or anything depending on node-pool) and any sort of domain context pattern (or any of several error reporting and APM tools which do).

For reference, the widely-used [redis](https://github.com/NodeRedis/node_redis/blob/ff9b727609ea125919828f7373e40082fd432eec/index.js#L877), [cassandra](https://github.com/datastax/nodejs-driver/blob/884535fcc50539db786712fda85d6b97c40909c6/lib/utils.js#L248), [mysql](https://github.com/mysqljs/mysql/blob/2aa8b6c8ea2eb93d4d2afa42920362b707e39aed/lib/Connection.js#L25), and [postgres](https://github.com/brianc/node-postgres/pull/531) drivers handle this correctly, among others.