### PR TITLE
Use Promise library provided in config in Deferred

### DIFF
--- a/lib/Deferred.js
+++ b/lib/Deferred.js
@@ -6,7 +6,7 @@
 
 class Deferred {
 
-  constructor () {
+  constructor (Promise) {
     this._state = Deferred.PENDING
     this._resolve = undefined
     this._reject = undefined

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -258,7 +258,7 @@ class Pool extends EventEmitter {
       // TODO: do need to trigger anything before we leave?
       return false
     }
-    const loan = new ResourceLoan(pooledResource)
+    const loan = new ResourceLoan(pooledResource, this._Promise)
     this._resourceLoans.set(pooledResource.obj, loan)
     pooledResource.allocate()
     clientResourceRequest.resolve(pooledResource.obj)
@@ -399,7 +399,7 @@ class Pool extends EventEmitter {
       return this._Promise.reject(new Error('max waitingClients count exceeded'))
     }
 
-    const resourceRequest = new ResourceRequest(this._config.acquireTimeoutMillis)
+    const resourceRequest = new ResourceRequest(this._config.acquireTimeoutMillis, this._Promise)
     this._waitingClientsQueue.enqueue(resourceRequest, priority)
     this._dispense()
 

--- a/lib/ResourceLoan.js
+++ b/lib/ResourceLoan.js
@@ -13,8 +13,8 @@ class ResourceLoan extends Deferred {
    * @param  {PooledResource} pooledResource the PooledResource this loan belongs to
    * @return {[type]}                [description]
    */
-  constructor (pooledResource) {
-    super()
+  constructor (pooledResource, Promise) {
+    super(Promise)
     this._creationTimestamp = Date.now()
     this.pooledResource = pooledResource
   }

--- a/lib/ResourceRequest.js
+++ b/lib/ResourceRequest.js
@@ -20,8 +20,8 @@ class ResourceRequest extends Deferred {
    * [constructor description]
    * @param  {Number} ttl     timeout
    */
-  constructor (ttl) {
-    super()
+  constructor (ttl, Promise) {
+    super(Promise)
     this._creationTimestamp = Date.now()
     this._timeout = null
 

--- a/test/resource-request-test.js
+++ b/test/resource-request-test.js
@@ -3,7 +3,7 @@ var ResourceRequest = require('../lib/ResourceRequest')
 
 tap.test('can be created', function (t) {
   var create = function () {
-    var request = new ResourceRequest() // eslint-disable-line no-unused-vars
+    var request = new ResourceRequest(undefined, Promise) // eslint-disable-line no-unused-vars
   }
   t.doesNotThrow(create)
   t.end()
@@ -17,7 +17,7 @@ tap.test('times out when created with a ttl', function (t) {
   var resolve = function (r) {
     t.fail('should not resolve')
   }
-  var request = new ResourceRequest(10) // eslint-disable-line no-unused-vars
+  var request = new ResourceRequest(10, Promise) // eslint-disable-line no-unused-vars
 
   request.promise.then(resolve, reject)
 })
@@ -31,7 +31,7 @@ tap.test('calls resolve when resolved', function (t) {
   var reject = function (err) {
     t.error(err)
   }
-  var request = new ResourceRequest()
+  var request = new ResourceRequest(undefined, Promise)
   request.promise.then(resolve, reject)
   request.resolve(resource)
 })
@@ -40,7 +40,7 @@ tap.test('removeTimeout removes the timeout', function (t) {
   var reject = function (err) {
     t.error(err)
   }
-  var request = new ResourceRequest(10)
+  var request = new ResourceRequest(10, Promise)
   request.promise.then(undefined, reject)
   request.removeTimeout()
   setTimeout(function () {
@@ -49,7 +49,7 @@ tap.test('removeTimeout removes the timeout', function (t) {
 })
 
 tap.test('does nothing if resolved more than once', function (t) {
-  var request = new ResourceRequest()
+  var request = new ResourceRequest(undefined, Promise)
   t.doesNotThrow(function () {
     request.resolve({})
   })


### PR DESCRIPTION
Deferred always uses native Promises, even when a custom Promise library is
supplied in the configuration.

This means the promise returned from acquire() is always native.