### PR TITLE
drain should be async always

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -441,6 +441,14 @@ Pool.prototype.returnToPool = function returnToPool (obj) {
   this.release(obj)
 }
 
+function invoke (cb) {
+  if (typeof setImmediate === 'function') {
+    setImmediate(cb)
+  } else {
+    setTimeout(cb, 0)
+  }
+}
+
 /**
  * Disallow any new requests and let the request backlog dissapate.
  *
@@ -463,7 +471,7 @@ Pool.prototype.drain = function drain (callback) {
       // wait until all objects have been released.
       setTimeout(check, 100)
     } else if (callback) {
-      callback()
+      invoke(callback)
     }
   }
   check()
@@ -494,7 +502,7 @@ Pool.prototype.destroyAllNow = function destroyAllNow (callback) {
   this._removeIdleScheduled = false
   clearTimeout(this._removeIdleTimer)
   if (callback) {
-    callback()
+    invoke(callback)
   }
 }
 


### PR DESCRIPTION
The drain function should always invoke the callback asynchronously.
As it is, if the first two conditions are not satisfied, then callback
will be executed synchronously.

---

Refer: https://github.com/coopernurse/node-pool/pull/139

cc @sandfox 