### PR TITLE
Invoke `Map.values` instead of reference

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -497,7 +497,7 @@ class Pool extends EventEmitter {
 
   // FIXME: this is a horrific mess
   __allResourcesReturned () {
-    const ps = Array.from(this._resourceLoans.values)
+    const ps = Array.from(this._resourceLoans.values())
     .map((loan) => loan.promise)
     .map(reflector)
     return this._Promise.all(ps)


### PR DESCRIPTION
`Map.values` is a function. This fixes a bug where the pool would not drain & clear properly.