### PR TITLE
pool.destroy didn't re-dispense resources

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -455,6 +455,8 @@ class Pool extends EventEmitter {
 
     pooledResource.deallocate()
     this._destroy(pooledResource)
+
+    this._dispense()
     return this._Promise.resolve()
   }
 

--- a/test/generic-pool-test.js
+++ b/test/generic-pool-test.js
@@ -599,7 +599,7 @@ tap.test('validate acquires object from the pool', function (t) {
   .catch(t.threw)
 })
 
-tap.test('release to pool should work', function(t) {
+tap.test('release to pool should work', function (t) {
   const pool = createPool({
     create: function () {
       return Promise.resolve({ id: 'validId' })
@@ -632,7 +632,7 @@ tap.test('release to pool should work', function(t) {
   .catch(t.threw)
 })
 
-tap.test('destroy should redispense', function(t) {
+tap.test('destroy should redispense', function (t) {
   const pool = createPool({
     create: function () {
       return Promise.resolve({ id: 'validId' })

--- a/test/generic-pool-test.js
+++ b/test/generic-pool-test.js
@@ -598,3 +598,69 @@ tap.test('validate acquires object from the pool', function (t) {
   })
   .catch(t.threw)
 })
+
+tap.test('release to pool should work', function(t) {
+  const pool = createPool({
+    create: function () {
+      return Promise.resolve({ id: 'validId' })
+    },
+    validate: function (resource) {
+      return Promise.resolve(true)
+    },
+    destroy: function (client) {},
+    max: 1
+  })
+
+  pool.acquire()
+  .then(function (obj) {
+    t.equal(pool.available, 0)
+    t.equal(pool.borrowed, 1)
+    t.equal(pool.pending, 1)
+    pool.release(obj)
+  })
+  .catch(t.threw)
+
+  pool.acquire()
+  .then(function (obj) {
+    t.equal(pool.available, 0)
+    t.equal(pool.borrowed, 1)
+    t.equal(pool.pending, 0)
+    pool.release(obj)
+    utils.stopPool(pool)
+    t.end()
+  })
+  .catch(t.threw)
+})
+
+tap.test('destroy should redispense', function(t) {
+  const pool = createPool({
+    create: function () {
+      return Promise.resolve({ id: 'validId' })
+    },
+    validate: function (resource) {
+      return Promise.resolve(true)
+    },
+    destroy: function (client) {},
+    max: 1
+  })
+
+  pool.acquire()
+  .then(function (obj) {
+    t.equal(pool.available, 0)
+    t.equal(pool.borrowed, 1)
+    t.equal(pool.pending, 1)
+    pool.destroy(obj)
+  })
+  .catch(t.threw)
+
+  pool.acquire()
+  .then(function (obj) {
+    t.equal(pool.available, 0)
+    t.equal(pool.borrowed, 1)
+    t.equal(pool.pending, 0)
+    pool.release(obj)
+    utils.stopPool(pool)
+    t.end()
+  })
+  .catch(t.threw)
+})


### PR DESCRIPTION
1. pool.acquire() twice
2. pool.destroy() the first resource
3. the second promise will never get resources till any other api triggered pool._dispense again (e.g. another `pool.acquire()`).

should dispense immediately after resources destroyed 