### PR TITLE
V2.5

### DIFF
--- a/lib/generic-pool.js
+++ b/lib/generic-pool.js
@@ -544,6 +544,10 @@ Pool.prototype.destroyAllNow = function destroyAllNow (callback) {
   this._removeIdleScheduled = false
   clearTimeout(this._removeIdleTimer)
 
+  if (todo === 0 && callback) {
+    invoke(callback)
+    return
+  }
   while (obj !== null && obj !== undefined) {
     this.destroy(obj.obj, function () {
       ++done


### PR DESCRIPTION
## Issue
If todo condition has already been met before while loop logic in `destroyAllNow`, `callback` is never called.

## Fix
Add an if check before entering while loop logic to see if todo is already 0.