### PR TITLE
Fix warning when using "bluebird"

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -282,6 +282,7 @@ class Pool extends EventEmitter {
     this._trackOperation(wrappedFactoryPromise, this._factoryCreateOperations)
     .then((resource) => {
       this._handleNewResource(resource)
+      return null
     })
     .catch((reason) => {
       this.emit(FACTORY_CREATE_ERROR, reason)


### PR DESCRIPTION
This fixes the warning:

```
Warning: a promise was created in a handler but was not returned from it
```

More info:
http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it