### PR TITLE
Prevent permanent waits from destroyed workers

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -302,11 +302,18 @@ class Pool extends EventEmitter {
    */
   _ensureMinimum () {
     if (this._draining === true) {
-      return
+      return;
     }
-    const minShortfall = this._config.min - this._count
+    const minShortfall = this._config.min - this._count;
+
+    if(minShortfall == 0){
+      const waiting  = this._waitingClientsQueue.size();
+      if(waiting > 0){
+        minShortFall = diff = Math.min(waiting, this._config.max - this._count);
+      }
+    }
     for (let i = 0; i < minShortfall; i++) {
-      this._createResource()
+      this._createResource();
     }
   }
 


### PR DESCRIPTION

* There are many errors due to pools being configured with min: 0
    but then running out of workers while there is still work to do
* This results in missed work, infinite loops and timeouts
* A solution is to ensure that if we still have work todo
    that we make sure we still have some workers to do them

See:

* brianc/node-pg-pool#48
* strongloop/loopback-connector-postgresql#231
