### PR TITLE
Bug #175 - Retry Create Resource

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const promiseRetry = require('promise-retry');
 const EventEmitter = require('events').EventEmitter
 
 const factoryValidator = require('./factoryValidator')
@@ -276,7 +277,10 @@ class Pool extends EventEmitter {
    */
   _createResource () {
     // An attempt to create a resource
-    const factoryPromise = this._factory.create()
+    const factoryPromise = promiseRetry((retry, attempt) => {
+      return this._factory.create()
+        .catch(retry);
+    })
     const wrappedFactoryPromise = this._Promise.resolve(factoryPromise)
 
     this._trackOperation(wrappedFactoryPromise, this._factoryCreateOperations)

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "eslint-plugin-standard": "^2.0.0",
     "tap": "^8.0.0"
   },
+  "dependencies": {
+    "promise-retry": "^1.1.1"
+  },
   "engines": {
     "node": ">= 4"
   },


### PR DESCRIPTION
This PR attempts to fix the issue where _dispense and _createResource will infinitely invoke each other thus blocking the thread.  This fix includes the promise-retry library for wrapping the factory.create() method in a promise-retry object.  