### PR TITLE
handle factoryCreate fail

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -314,6 +314,10 @@ class Pool extends EventEmitter {
         return null;
       })
       .catch(reason => {
+        const clientResourceRequest = this._waitingClientsQueue.dequeue();
+        if (clientResourceRequest) {
+          clientResourceRequest.reject(reason);
+        }
         this.emit(FACTORY_CREATE_ERROR, reason);
         this._dispense();
       });


### PR DESCRIPTION
if don't  do this ,it would  call  factory.create() again and again . or I can do like this outside.
const pool = genericPool.createPool(factory, options);
  pool.on('factoryCreateError', function (err) {
    const clientResourceRequest = pool._waitingClientsQueue.dequeue();
    if (clientResourceRequest) {
      clientResourceRequest.reject(err);
    }
  })
Need change _waitingClientsQueue -> waitingClientsQueue and defined Pool.FACTORY_CREATE_ERROR = FACTORY_CREATE_ERROR;