### PR TITLE
fix(Pool): continue iterating when reaching DoubleLinkedList end

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -362,7 +362,7 @@ class Pool extends EventEmitter {
       // list and can reset the cursor.
       if (iterationResult.done === true && this._availableObjects.length > 0) {
         this._evictionIterator.reset();
-        break;
+        continue;
       }
 
       const resource = iterationResult.value;


### PR DESCRIPTION
After reaching the linked list end and reseting it, we should continue iterating to evict idle resources.