### PR TITLE
adjust object tracking to leave resources in limbo after creation

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -306,24 +306,22 @@ class Pool extends EventEmitter {
   _createResource() {
     // An attempt to create a resource
     const factoryPromise = this._factory.create();
-    const wrappedFactoryPromise = this._Promise.resolve(factoryPromise);
+    const wrappedFactoryPromise = this._Promise
+      .resolve(factoryPromise)
+      .then(resource => {
+        const pooledResource = new PooledResource(resource);
+        this._allObjects.add(pooledResource);
+        this._addPooledResourceToAvailableObjects(pooledResource);
+      });
 
     this._trackOperation(wrappedFactoryPromise, this._factoryCreateOperations)
-      .then(resource => {
-        this._handleNewResource(resource);
-        return null;
+      .then(() => {
+        this._dispense();
       })
       .catch(reason => {
         this.emit(FACTORY_CREATE_ERROR, reason);
         this._dispense();
       });
-  }
-
-  _handleNewResource(resource) {
-    const pooledResource = new PooledResource(resource);
-    this._allObjects.add(pooledResource);
-    // TODO: check we aren't exceding our maxPoolSize before doing
-    this._dispatchPooledResourceToNextWaitingClient(pooledResource);
   }
 
   /**

--- a/test/GH-159-test.js
+++ b/test/GH-159-test.js
@@ -1,0 +1,71 @@
+const tap = require("tap");
+const createPool = require("../").createPool;
+const utils = require("./utils");
+const ResourceFactory = utils.ResourceFactory;
+
+class ResourceFactoryDelayCreateEachSecond {
+  constructor() {
+    this.callCreate = 0;
+    this.created = 0;
+    this.destroyed = 0;
+    this.bin = [];
+  }
+
+  create() {
+    const that = this;
+    console.log(`** create call ${that.callCreate}`);
+    return new Promise(resolve => {
+      if (that.callCreate % 2 === 0) {
+        setTimeout(function() {
+          console.log(`** created ${that.created}`);
+          resolve({ id: that.created++ });
+        }, 10);
+      } else {
+        console.log(`** created ${that.created}`);
+        resolve({ id: that.created++ });
+      }
+      that.callCreate++;
+    });
+  }
+
+  validate() {
+    return Promise.resolve(true);
+  }
+
+  destroy(resource) {
+    console.log(`** destroying ${resource.id}`);
+    this.destroyed++;
+    this.bin.push(resource);
+    return Promise.resolve();
+  }
+}
+
+tap.test("tests drain clear with autostart and min > 0", function(t) {
+  const count = 5;
+  let acquired = 0;
+
+  const resourceFactory = new ResourceFactoryDelayCreateEachSecond();
+  const config = {
+    max: 10,
+    min: 1,
+    evictionRunIntervalMillis: 500,
+    idleTimeoutMillis: 30000,
+    testOnBorrow: true,
+    autostart: true
+  };
+  const pool = createPool(resourceFactory, config);
+
+  return pool
+    .drain()
+    .then(function() {
+      console.log("** pool drained");
+      return pool.clear();
+    })
+    .then(function() {
+      console.log("** pool cleared");
+      t.equal(resourceFactory.created, resourceFactory.destroyed);
+    })
+    .then(function() {
+      t.end();
+    });
+});


### PR DESCRIPTION
Newly created resources would have their creation operation marked as
finished yet only be tracked in the "allObjects" which would allow a pool
to clear without removing them