### PR TITLE
Pool.clear() promise should resolve with no value

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -616,7 +616,7 @@ class Pool extends EventEmitter {
       const reflectedDestroyPromises = Array.from(
         this._factoryDestroyOperations
       ).map(reflector);
-      return this._Promise.all(reflectedDestroyPromises);
+      return reflector(this._Promise.all(reflectedDestroyPromises));
     });
   }
 

--- a/test/generic-pool-test.js
+++ b/test/generic-pool-test.js
@@ -257,6 +257,49 @@ tap.test("tests drain", function(t) {
     });
 });
 
+tap.test("clear promise resolves with no value", function(t) {
+  let resources = [];
+  const factory = {
+    create: function create() {
+      return new Promise(function tryCreate(resolve, reject) {
+        let resource = resources.shift();
+        if (resource) {
+          resolve(resource);
+        } else {
+          process.nextTick(tryCreate.bind(this, resolve, reject));
+        }
+      });
+    },
+    destroy: function() {
+      return Promise.resolve();
+    }
+  };
+  const pool = createPool(factory, { max: 3, min: 3 });
+  Promise.all([pool.acquire(), pool.acquire(), pool.acquire()]).then(all => {
+    for (let resource of all) {
+      process.nextTick(pool.release.bind(pool), resource);
+    }
+  });
+
+  t.equal(pool.pending, 3, "all acquisitions pending");
+
+  pool
+    .drain()
+    .then(() => {
+      return pool.clear();
+    })
+    .then(resolved => {
+      t.equal(resolved, undefined, "clear promise resolves with no value");
+      t.end();
+    });
+
+  process.nextTick(() => {
+    resources.push("a");
+    resources.push("b");
+    resources.push("c");
+  });
+});
+
 tap.test("handle creation errors", function(t) {
   let created = 0;
   const resourceFactory = {

--- a/test/generic-pool-test.js
+++ b/test/generic-pool-test.js
@@ -276,18 +276,16 @@ tap.test("clear promise resolves with no value", function(t) {
   };
   const pool = createPool(factory, { max: 3, min: 3 });
   Promise.all([pool.acquire(), pool.acquire(), pool.acquire()]).then(all => {
-    for (let resource of all) {
+    all.forEach(resource => {
       process.nextTick(pool.release.bind(pool), resource);
-    }
+    });
   });
 
   t.equal(pool.pending, 3, "all acquisitions pending");
 
   pool
     .drain()
-    .then(() => {
-      return pool.clear();
-    })
+    .then(() => pool.clear())
     .then(resolved => {
       t.equal(resolved, undefined, "clear promise resolves with no value");
       t.end();


### PR DESCRIPTION
This is a simple one-liner, excepting the associated test.  Previously, the `Promise` that `Pool.clear()` returned would resolve with an array of `undefined` values because that `Promise` was created using `Promise.all()`, which resolves with an array of all the component `Promise`s' resolved values.  This was a minor annoyance in some [tape](https://github.com/substack/tape) unit tests because I would do something like 
```js
test('something with a pool', function(t) {
  // ...
  const pool = genericPool.createPool(/* ... */);
  // ...
  pool.drain().then(() => {
    return pool.clear()
  })
  .then(t.end, t.fail);  
});
```
The above test would fail because that array of `undefined` values would be passed to `t.end`, which fails the test if invoked with a truthy argument.  Of course this was easy to work around once I figured out what was actually happening, but in any event, resolving the `clear()` `Promise` with an array of `undefined` just seems undesirable.