### PR TITLE
Attempt to fix defaultEvictor.

### DIFF
--- a/lib/DefaultEvictor.js
+++ b/lib/DefaultEvictor.js
@@ -1,23 +1,31 @@
 "use strict";
 
 class DefaultEvictor {
-  evict(config, pooledResource, availableObjectsCount) {
-    const idleTime = Date.now() - pooledResource.lastIdleTime;
+    evict(config, pooledResource, availableObjectsCount) {
+        const idleTime = Date.now() - pooledResource.lastIdleTime;
 
-    if (
-      config.softIdleTimeoutMillis > 0 &&
-      config.softIdleTimeoutMillis < idleTime &&
-      config.min < availableObjectsCount
-    ) {
-      return true;
+        if (!idleTime) {
+            console.log('ERROR - idleTime is junk, evictig!', JSON.stringify({
+                idleTime,
+                pooledResource,
+            }));
+            return true;
+        }
+
+        if (
+            config.softIdleTimeoutMillis > 0 &&
+            config.softIdleTimeoutMillis < idleTime &&
+            config.min < availableObjectsCount
+        ) {
+            return true;
+        }
+
+        if (config.idleTimeoutMillis < idleTime) {
+            return true;
+        }
+
+        return false;
     }
-
-    if (config.idleTimeoutMillis < idleTime) {
-      return true;
-    }
-
-    return false;
-  }
 }
 
 module.exports = DefaultEvictor;


### PR DESCRIPTION
If `pooledResource` is not a `Resource` (but an `Error`), it won't have `lastIdleTime` thus all ifs are returning `false` meaning the `Resource` (which is already broken in some way) won't get evicted ever, they stay in the pool and this may result in a `ResourceRequest Timed Out` error (b/c all slots are occupied by stuck `Resource`s).
As a solution, `idleTime` is checked, and if it is falsy, the `Resource` gets evicted.

Signed-off-by: Daniel Schopper <scream314@gmail.com>