### PR TITLE
Add destroyTimeoutMillis option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ An optional object/dictionary with the any of the following properties:
 - `maxWaitingClients`: maximum number of queued requests allowed, additional `acquire` calls will be callback with an `err` in a future cycle of the event loop.
 - `testOnBorrow`: `boolean`: should the pool validate resources before giving them to clients. Requires that `factory.validate` is specified.
 - `acquireTimeoutMillis`: max milliseconds an `acquire` call will wait for a resource before timing out. (default no limit), if supplied should non-zero positive integer.
+- `destroyTimeoutMillis`: max milliseconds a `destroy` call will wait for a resource before timing out. (default no limit), if supplied should non-zero positive integer.
 - `fifo` : if true the oldest resources will be first to be allocated. If false the most recently released resources will be the first to be allocated. This in effect turns the pool's behaviour from a queue into a stack. `boolean`, (default true)
 - `priorityRange`: int between 1 and x - if set, borrowers can specify their relative priority in the queue if no resources are available.
                          see example.  (default 1)

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -135,7 +135,9 @@ class Pool extends EventEmitter {
     this._allObjects.delete(pooledResource);
     // NOTE: this maybe very bad promise usage?
     const destroyPromise = this._factory.destroy(pooledResource.obj);
-    const wrappedDestroyPromise = this._Promise.resolve(destroyPromise);
+    const wrappedDestroyPromise = this._config.destroyTimeoutMillis
+      ? this._Promise.resolve(this._applyDestroyTimeout(destroyPromise))
+      : this._Promise.resolve(destroyPromise);
 
     this._trackOperation(
       wrappedDestroyPromise,
@@ -146,6 +148,15 @@ class Pool extends EventEmitter {
 
     // TODO: maybe ensuring minimum pool size should live outside here
     this._ensureMinimum();
+  }
+
+  _applyDestroyTimeout(promise) {
+    const timeoutPromise = new this._Promise((resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error("destroy timed out"));
+      }, this._config.destroyTimeoutMillis).unref();
+    });
+    return this._Promise.race([timeoutPromise, promise]);
   }
 
   /**

--- a/lib/PoolDefaults.js
+++ b/lib/PoolDefaults.js
@@ -21,6 +21,7 @@ class PoolDefaults {
 
     // FIXME: no defaults!
     this.acquireTimeoutMillis = null;
+    this.destroyTimeoutMillis = null;
     this.maxWaitingClients = null;
 
     this.min = null;

--- a/lib/PoolOptions.js
+++ b/lib/PoolOptions.js
@@ -24,6 +24,9 @@ class PoolOptions {
    * @param {Number} [opts.acquireTimeoutMillis=null]
    *   Delay in milliseconds after which the an `acquire` call will fail. optional.
    *   Default: undefined. Should be positive and non-zero
+   * @param {Number} [opts.destroyTimeoutMillis=null]
+   *   Delay in milliseconds after which the an `destroy` call will fail, causing it to emit a factoryDestroyError event. optional.
+   *   Default: undefined. Should be positive and non-zero
    * @param {Number} [opts.priorityRange=1]
    *   The range from 1 to be treated as a valid priority
    * @param {Boolean} [opts.fifo=true]
@@ -70,6 +73,11 @@ class PoolOptions {
     if (opts.acquireTimeoutMillis) {
       // @ts-ignore
       this.acquireTimeoutMillis = parseInt(opts.acquireTimeoutMillis, 10);
+    }
+
+    if (opts.destroyTimeoutMillis) {
+      // @ts-ignore
+      this.destroyTimeoutMillis = parseInt(opts.destroyTimeoutMillis, 10);
     }
 
     if (opts.maxWaitingClients !== undefined) {

--- a/test/generic-pool-destroytimeout-test.js
+++ b/test/generic-pool-destroytimeout-test.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const tap = require("tap");
+const createPool = require("../").createPool;
+
+tap.test("destroyTimeout handles timed out destroy calls", function(t) {
+  const factory = {
+    create: function() {
+      return Promise.resolve({});
+    },
+    destroy: function() {
+      return new Promise(function(resolve) {
+        setTimeout(function() {
+          resolve();
+        }, 100);
+      });
+    }
+  };
+  const config = {
+    destroyTimeoutMillis: 20
+  };
+
+  const pool = createPool(factory, config);
+
+  pool
+    .acquire()
+    .then(function(resource) {
+      pool.destroy(resource);
+      return new Promise(function(resolve, reject) {
+        pool.on("factoryDestroyError", function(err) {
+          t.match(err, /destroy timed out/);
+          resolve();
+        });
+      });
+    })
+    .then(t.end)
+    .catch(t.error);
+});
+
+tap.test("destroyTimeout handles non timed out destroy calls", function(t) {
+  const myResource = {};
+  const factory = {
+    create: function() {
+      return Promise.resolve({});
+    },
+    destroy: function() {
+      return new Promise(function(resolve) {
+        setTimeout(function() {
+          resolve();
+        }, 10);
+      });
+    }
+  };
+
+  const config = {
+    destroyTimeoutMillis: 400
+  };
+
+  const pool = createPool(factory, config);
+
+  pool
+    .acquire()
+    .then(function(resource) {
+      pool.destroy(resource);
+      return new Promise(function(resolve) {
+        pool.on("factoryDestroyError", function(err) {
+          t.fail("wooops");
+        });
+        setTimeout(resolve, 20);
+      });
+    })
+    .then(t.end)
+    .catch(t.error);
+});


### PR DESCRIPTION
This PR adds the destroyTimeoutMillis pool option. When specified a destroy operation will timeout if the number of milliseconds is reached, causing a factoryDestroyError event to be emitted by the pool. The default value is null and if unspecified no timeout is added.