### PR TITLE
fix: unref setTimeout in pool

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -402,7 +402,7 @@ class Pool extends EventEmitter {
       this._scheduledEviction = setTimeout(() => {
         this._evict();
         this._scheduleEvictorRun();
-      }, this._config.evictionRunIntervalMillis);
+      }, this._config.evictionRunIntervalMillis).unref();
     }
   }
 


### PR DESCRIPTION
I'm using `generic-pool` in another library.
The end developer may not be aware there's a pool running under the hood. 
Thus unable to `drain().then(clear())`.

As a library, don't block the process quit. 
Simply `unref` all the `setTimeout`s.
